### PR TITLE
chore: Update CI to use 24.04

### DIFF
--- a/.github/workflows/build_and_publish_call.yaml
+++ b/.github/workflows/build_and_publish_call.yaml
@@ -33,15 +33,15 @@ jobs:
       id-token: write
       contents: write
       security-events: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       
       - name: Build Docker image
         run: |
@@ -62,7 +62,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v5.4.0
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install dependencies
       run: pip install tox
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v5.4.0
       with:
-        python-version: 3.10
+        python-version: "3.10"
       
     - name: Install dependencies
       run: pip install tox
@@ -53,7 +53,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v5.4.0
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install dependencies
       run: pip install tox

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -6,42 +6,57 @@ on:
 jobs:
   lint:
     name: Lint Check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5.4.0
+      with:
+        python-version: 3.10
 
     - name: Install dependencies
-      run: sudo apt-get install python3-pip tox
+      run: pip install tox
 
     - name: Lint code
       run: tox -e lint
   
   unit:
     name: Unit Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5.4.0
+      with:
+        python-version: 3.10
+      
     - name: Install dependencies
-      run: sudo apt-get install python3-pip tox
+      run: pip install tox
 
     - name: Run unit tests
       run: tox -e unit
   
   integration:
     name: Integration Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5.4.0
+      with:
+        python-version: 3.10
 
     - name: Install dependencies
-      run: sudo apt-get install python3-pip tox
+      run: pip install tox
 
     - name: Run integration tests
       run: tox -e integration


### PR DESCRIPTION
Closes #30 

This PR updates the CI to use `24.04`, as well as the versions of the `checkout`, `docker/setup-buildx` and `docker/login` actions:
- We also use `setup-python` to use `3.10` (this is different from most other repositories we maintain since they currently use `3.8`.