### PR TITLE
PoC: Support applying namespaced resources + Roles and RoleBindings

### DIFF
--- a/resource_dispatcher/src/server.py
+++ b/resource_dispatcher/src/server.py
@@ -106,6 +106,10 @@ def generate_manifests(manifest_folder: str, namespace: str) -> list[dict]:
                 manifest = yaml.safe_load(f)
             except ParserError as e:
                 raise e
-        manifest["metadata"]["namespace"] = namespace
-        manifests.append(manifest)
+        if 'namespace' in manifest["metadata"]:
+            if manifest["metadata"]["namespace"] == namespace:
+                manifests.append(manifest)
+        else:
+            manifest["metadata"]["namespace"] = namespace
+            manifests.append(manifest)
     return manifests


### PR DESCRIPTION
* feat: Enable applying namespaced resources
If a resource definition already has a namespace, then apply it only to
that namespace. If there is none, then apply it to all user namespaces.
* feat: Support applying Roles and RoleBindings
  * Support applying Roles and RoleBindings.
  * Handle namespaced RoleBindings that have subjects of type
  * ServiceAccount.

This PoC works with PRs:
* https://github.com/canonical/resource-dispatcher/pull/96