### PR TITLE
[PRA-70] Add support for roles and rolebindings to be synced

### DIFF
--- a/resource_dispatcher/src/server.py
+++ b/resource_dispatcher/src/server.py
@@ -71,8 +71,10 @@ def server_factory(controller_port: int, label: str, folder: str, url: str = "")
                 "resources-ready": str(
                     len(attachments["Secret.v1"]) == desired_secrets_count
                     and len(attachments["ServiceAccount.v1"]) == desired_svc_accounts_count
-                    and len(attachments["Role.v1"]) == desired_roles_count
-                    and len(attachments["RoleBinding.v1"]) == desired_role_bindings_count
+                    and len(attachments["Role.rbac.authorization.k8s.io/v1"])
+                    == desired_roles_count
+                    and len(attachments["RoleBinding.rbac.authorization.k8s.io/v1"])
+                    == desired_role_bindings_count
                     and len(attachments["PodDefault.kubeflow.org/v1alpha1"])
                     == desired_pod_defaults_count
                 )

--- a/resource_dispatcher/tests/unit/test_server.py
+++ b/resource_dispatcher/tests/unit/test_server.py
@@ -32,7 +32,7 @@ class TestServer:
         """Test if server_factory creates HTTPServer object."""
         server = server_factory(PORT, LABEL, FOLDER)
 
-        assert type(server) == HTTPServer
+        assert type(server) is HTTPServer
         assert server.server_port == PORT
 
     def test_generate_manifests(self):


### PR DESCRIPTION
This PR aims to add support for new K8s resources `roles` and `rolebindings` to be synced by the `resource-dispatcher` charm.