### PR TITLE
fix: grant permissions for daemon user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY requirements.txt /app
 RUN set -eux; \
     pip3 install -r requirements.txt --no-cache-dir
 
-COPY ./resource_dispatcher /app 
+COPY --chown=584792:584792 --chmod=770 ./resource_dispatcher /app
 
 EXPOSE 80
 CMD ["python3", "main.py"]


### PR DESCRIPTION
This pull request allows to run the resource-dispatcher workload of the charm as a non-root user with user ID and group ID `584792` ("daemon", in Rockcraft) by changing permissions of filesystem locations manipulated by the charm workload.

For broader context, see https://github.com/canonical/resource-dispatcher/pull/145#issuecomment-3887122810.

Tested in https://github.com/canonical/resource-dispatcher/pull/146 and in https://github.com/canonical/resource-dispatcher-rock/pull/19.